### PR TITLE
Check if project already attached to shared vpc

### DIFF
--- a/internal/reconcilers/google/gcp/reconciler.go
+++ b/internal/reconcilers/google/gcp/reconciler.go
@@ -641,6 +641,17 @@ func (r *googleGcpReconciler) deleteDefaultVPCNetworkRules(ctx context.Context, 
 }
 
 func (r *googleGcpReconciler) attachProjectToSharedVPC(ctx context.Context, client *apiclient.APIClient, naisTeam *protoapi.Team, teamProjectId string, clusterProjectId string, log logrus.FieldLogger) error {
+	getXpnResourcesResult, err := r.gcpServices.ComputeProjectsService.GetXpnResources(clusterProjectId).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	for _, xpnResource := range getXpnResourcesResult.Resources {
+		if xpnResource.Id == teamProjectId {
+			log.Debugf("Team project %q is already attached to shared vpc in %q", teamProjectId, clusterProjectId)
+			return nil
+		}
+	}
+
 	req := &compute.ProjectsEnableXpnResourceRequest{
 		XpnResource: &compute.XpnResourceId{
 			Id:   teamProjectId,

--- a/internal/reconcilers/google/gcp/reconciler_test.go
+++ b/internal/reconcilers/google/gcp/reconciler_test.go
@@ -440,7 +440,7 @@ func TestReconcile(t *testing.T) {
 			// get team projects attached to shared vpc
 			func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
-					t.Errorf("expected HTTP POST, got: %q", r.Method)
+					t.Errorf("expected HTTP GET, got: %q", r.Method)
 				}
 
 				if expected := "/projects/" + clusterProjectID + "/getXpnResources"; r.URL.Path != expected {

--- a/internal/reconcilers/google/gcp/reconciler_test.go
+++ b/internal/reconcilers/google/gcp/reconciler_test.go
@@ -437,6 +437,23 @@ func TestReconcile(t *testing.T) {
 				_, _ = w.Write(resp)
 			},
 
+			// get team projects attached to shared vpc
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected HTTP POST, got: %q", r.Method)
+				}
+
+				if expected := "/projects/" + clusterProjectID + "/getXpnResources"; r.URL.Path != expected {
+					t.Errorf("expected path %q, got %q", expected, r.URL.Path)
+				}
+
+				getXpnResources := compute.ProjectsGetXpnResources{
+					Resources: []*compute.XpnResourceId{},
+				}
+				resp, _ := getXpnResources.MarshalJSON()
+				_, _ = w.Write(resp)
+			},
+
 			// attach team project to shared vpc
 			func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {


### PR DESCRIPTION
If already attached, we don't need to do it again.