### PR TITLE
* add environment alias for migrating legacy clusters

### DIFF
--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -40,6 +40,7 @@ values:
 
   clusterAlias:
     displayName: Cluster aliases
+    description: Comma separated list of colon separeted key:value cluster aliases (e.g. dev:dev-gcp,prod:prod-gcp)
     config:
       type: string_array
 
@@ -96,7 +97,7 @@ values:
   gcp.billingAccount:
     displayName: Billing account
     computed:
-      template: '{{ .Env.billing_account | quote }}'
+      template: "{{ .Env.billing_account | quote }}"
 
   gcp.clusters:
     displayName: Cluster information
@@ -118,7 +119,7 @@ values:
   gcp.workloadIdentityPoolName:
     displayName: Google workload identity pool name
     computed:
-      template: '{{ .Env.nais_identity_pool_name | quote }}'
+      template: "{{ .Env.nais_identity_pool_name | quote }}"
 
   grafana.endpoint:
     displayName: Grafana API endpoint

--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -38,6 +38,11 @@ values:
       template: |
         {{ .Env.tenant_domain | quote }}
 
+  clusterAlias:
+    displayName: Cluster aliases
+    config:
+      type: string_array
+
   reconcilersToEnable:
     displayName: Reconcilers to enable
     description: Comma separated list of reconcilers to enable. Changing this value after the reconciler has been registered will not have any effect.

--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -40,7 +40,7 @@ values:
 
   clusterAlias:
     displayName: Cluster aliases
-    description: Comma separated list of colon separeted key:value cluster aliases (e.g. dev:dev-gcp,prod:prod-gcp)
+    description: Each entry must be colon separeted key:value cluster aliases (e.g. dev:dev-gcp)
     config:
       type: string_array
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: LISTEN_ADDRESS
               value: :3005
             - name: CLUSTER_ALIAS
-              value: {{ .Values.clusterAlias }}
+              value: {{ .Values.clusterAlias | join "," | quote }}
             - name: TENANT_DOMAIN
               value: {{ .Values.tenantDomain }}
             - name: TENANT_NAME

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: {{ .Values.naisAPI.target }}
             - name: LISTEN_ADDRESS
               value: :3005
+            - name: CLUSTER_ALIAS
+              value: {{ .Values.clusterAlias }}
             - name: TENANT_DOMAIN
               value: {{ .Values.tenantDomain }}
             - name: TENANT_NAME

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,6 +10,7 @@ logLevel: info
 logFormat: json
 googleManagementProjectID: # mapped in fasit
 tenantDomain: # mapped in fasit
+clusterAlias: []
 reconcilersToEnable: "google:gcp:project,google:workspace-admin,nais:namespace,nais:deploy,google:gcp:gar,google:gcp:cdn,grafana"
 fasit:
   tenant:

--- a/internal/cmd/reconciler/config/config.go
+++ b/internal/cmd/reconciler/config/config.go
@@ -127,6 +127,9 @@ type Config struct {
 	// TenantName The name of the tenant.
 	TenantName string `env:"TENANT_NAME,default=example"`
 
+	// ClusterAlias The cluster alias for legacy migration
+	ClusterAlias map[string]string `env:"CLUSTER_ALIAS"`
+
 	// Reconcilers to enable the first time it is registered (one time only) in the NAIS API
 	// If you later would like do enable/disable a reconciler, you can do so through the Console
 	ReconcilersToEnable []string `env:"RECONCILERS_TO_ENABLE"`

--- a/internal/cmd/reconciler/main.go
+++ b/internal/cmd/reconciler/main.go
@@ -133,7 +133,7 @@ func run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}
 	log.WithField("duration", time.Since(start).String()).Debug("Created NAIS deploy reconciler")
 
-	googleGcpReconciler, err := google_gcp_reconciler.New(ctx, cfg.GCP.Clusters, cfg.GCP.ServiceAccountEmail, cfg.TenantDomain, cfg.TenantName, cfg.GCP.CnrmRole, cfg.GCP.BillingAccount, cfg.FeatureFlags)
+	googleGcpReconciler, err := google_gcp_reconciler.New(ctx, cfg.GCP.Clusters, cfg.GCP.ServiceAccountEmail, cfg.TenantDomain, cfg.TenantName, cfg.GCP.CnrmRole, cfg.GCP.BillingAccount, cfg.ClusterAlias, cfg.FeatureFlags)
 	if err != nil {
 		return fmt.Errorf("error when creating Google GCP reconciler: %w", err)
 	}

--- a/internal/reconcilers/google/gcp/reconciler.go
+++ b/internal/reconcilers/google/gcp/reconciler.go
@@ -60,6 +60,7 @@ type googleGcpReconciler struct {
 	tenantDomain   string
 	tenantName     string
 	flags          config.FeatureFlags
+	clusterAlias   map[string]string
 }
 
 type OptFunc func(*googleGcpReconciler)
@@ -70,7 +71,7 @@ func WithGcpServices(gcpServices *GcpServices) OptFunc {
 	}
 }
 
-func New(ctx context.Context, clusters gcp.Clusters, serviceAccountEmail, tenantDomain, tenantName, cnrmRoleName, billingAccount string, flags config.FeatureFlags, opts ...OptFunc) (reconcilers.Reconciler, error) {
+func New(ctx context.Context, clusters gcp.Clusters, serviceAccountEmail, tenantDomain, tenantName, cnrmRoleName, billingAccount string, clusterAlias map[string]string, flags config.FeatureFlags, opts ...OptFunc) (reconcilers.Reconciler, error) {
 	r := &googleGcpReconciler{
 		billingAccount: billingAccount,
 		clusters:       clusters,
@@ -78,6 +79,7 @@ func New(ctx context.Context, clusters gcp.Clusters, serviceAccountEmail, tenant
 		tenantDomain:   tenantDomain,
 		tenantName:     tenantName,
 		flags:          flags,
+		clusterAlias:   clusterAlias,
 	}
 
 	for _, opt := range opts {
@@ -136,6 +138,10 @@ func (r *googleGcpReconciler) Reconcile(ctx context.Context, client *apiclient.A
 			continue
 		}
 
+		if _, isAlias := r.clusterAlias[env.EnvironmentName]; isAlias {
+			continue
+		}
+
 		projectID := GenerateProjectID(r.tenantDomain, env.EnvironmentName, naisTeam.Slug)
 		log.WithField("project_id", projectID).Debugf("generated GCP project ID")
 		teamProject, err := r.getOrCreateProject(ctx, client, projectID, env, cluster.TeamsFolderID, naisTeam)
@@ -143,13 +149,22 @@ func (r *googleGcpReconciler) Reconcile(ctx context.Context, client *apiclient.A
 			return fmt.Errorf("get or create a GCP project %q for team %q in environment %q: %w", projectID, naisTeam.Slug, env.EnvironmentName, err)
 		}
 
-		_, err = client.Teams().SetTeamEnvironmentExternalReferences(ctx, &protoapi.SetTeamEnvironmentExternalReferencesRequest{
-			Slug:            naisTeam.Slug,
-			EnvironmentName: env.EnvironmentName,
-			GcpProjectId:    &teamProject.ProjectId,
-		})
-		if err != nil {
-			return fmt.Errorf("set GCP project ID for team %q in environment %q: %w", naisTeam.Slug, env.EnvironmentName, err)
+		envList := []string{env.EnvironmentName}
+		for alias, original := range r.clusterAlias {
+			if original == env.EnvironmentName {
+				envList = append(envList, alias)
+			}
+		}
+
+		for _, envName := range envList {
+			_, err = client.Teams().SetTeamEnvironmentExternalReferences(ctx, &protoapi.SetTeamEnvironmentExternalReferencesRequest{
+				Slug:            naisTeam.Slug,
+				EnvironmentName: envName,
+				GcpProjectId:    &teamProject.ProjectId,
+			})
+			if err != nil {
+				return fmt.Errorf("set GCP project ID for team %q in environment %q: %w", naisTeam.Slug, envName, err)
+			}
 		}
 
 		labels := map[string]string{
@@ -214,6 +229,11 @@ func (r *googleGcpReconciler) Delete(ctx context.Context, client *apiclient.APIC
 		env := it.Value()
 		if !env.Gcp || env.GcpProjectId == nil {
 			log.Warning("skipping environment, no GCP project or project is already deleted")
+			continue
+		}
+
+		if _, isAlias := r.clusterAlias[env.EnvironmentName]; isAlias {
+			log.Infof("skipping alias environment %q", env.EnvironmentName)
 			continue
 		}
 

--- a/internal/reconcilers/google/gcp/reconciler_test.go
+++ b/internal/reconcilers/google/gcp/reconciler_test.go
@@ -56,6 +56,8 @@ var (
 		Slug: teamSlug,
 	}
 	ctx = context.Background()
+
+	aliasList = map[string]string{"prodalias": env}
 )
 
 func TestReconcile(t *testing.T) {
@@ -68,7 +70,7 @@ func TestReconcile(t *testing.T) {
 			Return(nil, fmt.Errorf("some error")).
 			Once()
 
-		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
+		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,7 +84,7 @@ func TestReconcile(t *testing.T) {
 		log, _ := logrustest.NewNullLogger()
 
 		apiClient, _ := apiclient.NewMockClient(t)
-		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
+		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -96,7 +98,7 @@ func TestReconcile(t *testing.T) {
 		log, _ := logrustest.NewNullLogger()
 
 		apiClient, _ := apiclient.NewMockClient(t)
-		reconcilers, err := google_gcp_reconciler.New(ctx, gcp.Clusters{}, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
+		reconcilers, err := google_gcp_reconciler.New(ctx, gcp.Clusters{}, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -137,6 +139,14 @@ func TestReconcile(t *testing.T) {
 			SetTeamEnvironmentExternalReferences(mock.Anything, &protoapi.SetTeamEnvironmentExternalReferencesRequest{
 				Slug:            teamSlug,
 				EnvironmentName: env,
+				GcpProjectId:    &expectedTeamProjectID,
+			}).
+			Return(&protoapi.SetTeamEnvironmentExternalReferencesResponse{}, nil).
+			Once()
+		mockServer.Teams.EXPECT().
+			SetTeamEnvironmentExternalReferences(mock.Anything, &protoapi.SetTeamEnvironmentExternalReferencesRequest{
+				Slug:            teamSlug,
+				EnvironmentName: "prodalias",
 				GcpProjectId:    &expectedTeamProjectID,
 			}).
 			Return(&protoapi.SetTeamEnvironmentExternalReferencesResponse{}, nil).
@@ -503,7 +513,7 @@ func TestReconcile(t *testing.T) {
 			ProjectsRolesService:                  iamService.Projects.Roles,
 		}
 
-		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, flags, google_gcp_reconciler.WithGcpServices(gcpServices))
+		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, flags, google_gcp_reconciler.WithGcpServices(gcpServices))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -523,7 +533,7 @@ func TestDelete(t *testing.T) {
 			Environments(mock.Anything, &protoapi.ListTeamEnvironmentsRequest{Slug: teamSlug, Limit: 100}).
 			Return(nil, fmt.Errorf("some error")).
 			Once()
-		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
+		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -547,7 +557,7 @@ func TestDelete(t *testing.T) {
 			}, nil).
 			Once()
 
-		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
+		reconcilers, err := google_gcp_reconciler.New(ctx, clusters, clusterProjectID, tenantDomain, tenantName, cnrmRoleName, billingAccount, aliasList, config.FeatureFlags{}, google_gcp_reconciler.WithGcpServices(&google_gcp_reconciler.GcpServices{}))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
* add new parameter for feature - clusteralias
* add config parameter
* add handling of environments in reconciler for gcp
* add environment alias to reconciler test

Co-authored-by: Roger Bjørnstad <roger.bjornstad@nav.no>
Co-authored-by: Vegar Sechmann Molvig <vegar.sechmann.molvig@nav.no>
