### PR TITLE
Remove linkerd namespace labels and set gcp project label

### DIFF
--- a/internal/reconcilers/nais/namespace/reconciler.go
+++ b/internal/reconcilers/nais/namespace/reconciler.go
@@ -131,11 +131,7 @@ func (r *naisNamespaceReconciler) ensureNamespace(ctx context.Context, naisTeam 
 	metav1.SetMetaDataAnnotation(&ns.ObjectMeta, "cnrm.cloud.google.com/project-id", ptr.Deref(env.GcpProjectId, ""))
 	metav1.SetMetaDataAnnotation(&ns.ObjectMeta, "replicator.nais.io/slackAlertsChannel", env.SlackAlertsChannel)
 	metav1.SetMetaDataLabel(&ns.ObjectMeta, "team", naisTeam.Slug)
-
-	// TODO: nuke this when legacy is dead
-	if env.EnvironmentName == "prod-gcp" || env.EnvironmentName == "dev-gcp" || env.EnvironmentName == "ci-gcp" {
-		metav1.SetMetaDataAnnotation(&ns.ObjectMeta, "linkerd.io/inject", "enabled")
-	}
+	metav1.SetMetaDataLabel(&ns.ObjectMeta, "google-cloud-project", ptr.Deref(env.GcpProjectId, ""))
 
 	_, err = c.Update(ctx, ns, metav1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
The `google-cloud-project` label is used by fluentbit to route team logs to the correct team project. It is not enough to have them as annotations. The name of the label is consistent with the default environment variable name for indicating gcp project id.

This Pull Request also removes linkerd-injection labels now that linkerd is out of the picture.
