### PR TITLE
fix: remove ClientTtl cap and increase MaxTtl to 1 year for CDN

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # ratchet:jdx/mise-action@v3
         with:
           cache: false
-      - uses: nais/platform-build-push-sign@8be8359cd90915318ee8ab5fbc8337d04937ae70 # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@a16d89d06262f12e3468a20b9cc70f5317290bab # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
           cache: false
       - id: version-info
         run: echo "go-version=$(mise current go)" >> $GITHUB_OUTPUT
-      - uses: nais/platform-build-push-sign@8be8359cd90915318ee8ab5fbc8337d04937ae70 # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@a16d89d06262f12e3468a20b9cc70f5317290bab # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nais/api-reconcilers
 
-go 1.26.0
+go 1.26.1
 
 tool (
 	github.com/securego/gosec/v2/cmd/gosec
@@ -73,7 +73,7 @@ require (
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chigopher/pathlib v0.19.1 // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chigopher/pathlib v0.19.1 h1:RoLlUJc0CqBGwq239cilyhxPNLXTK+HXoASGyGznx5A=
 github.com/chigopher/pathlib v0.19.1/go.mod h1:tzC1dZLW8o33UQpWkNkhvPwL5n4yyFRFm/jL1YGWFvY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
-github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=

--- a/internal/reconcilers/google/cdn/reconciler.go
+++ b/internal/reconcilers/google/cdn/reconciler.go
@@ -502,8 +502,8 @@ func (r *cdnReconciler) getOrCreateBackendBucket(ctx context.Context, naisTeam *
 		return backendBucket, nil
 	}
 
-	const defaultTTL = int32(3600)     // 1 hour
-	const defaultMaxTTL = int32(86400) // 1 year
+	const defaultTTL = int32(3600)        // 1 hour
+	const defaultMaxTTL = int32(31536000) // 1 year
 
 	req := &computepb.InsertBackendBucketRequest{
 		BackendBucketResource: &computepb.BackendBucket{
@@ -512,8 +512,12 @@ func (r *cdnReconciler) getOrCreateBackendBucket(ctx context.Context, naisTeam *
 				// Enables Cloud CDN to cache all static content served from the backend
 				// bucket. This includes content with a file extension that is typically
 				// associated with static content, such as .html, .css, and .js.
-				CacheMode:  new("CACHE_ALL_STATIC"),
-				ClientTtl:  ptr.To(defaultTTL),
+				CacheMode: new("CACHE_ALL_STATIC"),
+				// ClientTtl is intentionally not set. This allows teams to control
+				// browser caching via Cache-Control headers on their GCS objects.
+				// For example, hashed assets can use max-age=31536000, while
+				// index.html can use no-cache or no-store via the no_cache_paths
+				// input in the cdn-upload action.
 				DefaultTtl: ptr.To(defaultTTL),
 				MaxTtl:     ptr.To(defaultMaxTTL),
 				// If true then Cloud CDN will combine multiple concurrent cache fill

--- a/mise.toml
+++ b/mise.toml
@@ -3,5 +3,5 @@ pin = true
 task_output = "prefix"
 
 [tools]
-go = "1.26.0"
+go = "1.26.1"
 helm = "3.17.1"


### PR DESCRIPTION
## Summary

- Remove hardcoded `ClientTtl` (was 3600s/1 hour) that capped all `Cache-Control: max-age` headers sent to browsers
- Increase `MaxTtl` from 86400s (1 day) to 31536000s (1 year)
- Fix incorrect code comment that said "1 year" for the old 86400s value

## Background

A user [reported](https://nav-it.slack.com/archives/C09CHA215S5/p1773833944101119) that cdn.nav.no returns `Cache-Control: max-age=3600` (1 hour) for all assets, including hashed static files that should be cached much longer.

The root cause is that `ClientTtl` in the Google Cloud CDN backend bucket config was set to 3600s, which **caps** the `max-age` sent to browsers regardless of what teams set on their GCS objects. Even if a team sets `Cache-Control: max-age=31536000` on a content-hashed JS file, the CDN rewrites it to `max-age=3600`.

## Changes

**`ClientTtl` removed:** Teams now control browser caching via `Cache-Control` headers on their GCS objects. This enables the recommended pattern:
- Hashed assets (`app.a1b2c3.js`): `max-age=31536000` (1 year) — safe because filename changes on each build
- Entry points (`index.html`): `no-cache` or `no-store` via the `no_cache_paths` input in the cdn-upload action

**`MaxTtl` increased to 1 year:** Was 86400s (1 day), now 31536000s (1 year), allowing teams to actually use long cache durations.

**`DefaultTtl` unchanged:** Still 3600s (1 hour) as a sensible fallback for files without explicit `Cache-Control` headers.

## Important caveat

This only affects **newly created** backend buckets. Existing team backend buckets retain the old config and would need a separate migration or manual update to benefit from this change. We should consider either:
1. Making the reconciler update existing backend buckets (currently it skips if the bucket already exists)
2. A one-off migration script

## This is a quick win from a larger CDN feature review

The CDN feature is currently the least integrated feature on the platform (no nais.yaml field, no Console page, no cost visibility, no observability). A broader improvement effort could include:
- Letting teams configure cache policy declaratively
- CDN metrics (cache hit rate, traffic) in Console
- A dedicated CDN page in Console
- CLI support for cache invalidation