### PR TITLE
fix(gcp): kun adopter eksisterende prosjekt ved 409 hvis labels matcher teamet

### DIFF
--- a/internal/reconcilers/google/gcp/reconciler.go
+++ b/internal/reconcilers/google/gcp/reconciler.go
@@ -380,6 +380,13 @@ func (r *googleGcpReconciler) getOrCreateProject(ctx context.Context, projectID 
 		DisplayName: GetProjectDisplayName(naisTeam.Slug, environment.EnvironmentName),
 		Parent:      "folders/" + strconv.FormatInt(parentFolderID, 10),
 		ProjectId:   projectID,
+		// Set ownership labels at creation time so the project is identifiable as
+		// ours even if a later reconcile step fails before ensureProjectHasLabels
+		// runs. validateAdoptedProject relies on these when adopting after a 409.
+		Labels: map[string]string{
+			"team":             naisTeam.Slug,
+			ManagedByLabelName: ManagedByLabelValue,
+		},
 	}
 	operation, err := r.gcpServices.CloudResourceManagerProjectsService.Create(project).Do()
 	if err != nil {
@@ -403,7 +410,12 @@ func (r *googleGcpReconciler) getOrCreateProject(ctx context.Context, projectID 
 			return nil, fmt.Errorf("invalid number of projects in response: %+v", response.Projects)
 		}
 
-		return response.Projects[0], nil
+		adoptedProject := response.Projects[0]
+		if err := validateAdoptedProject(adoptedProject, naisTeam.Slug); err != nil {
+			return nil, fmt.Errorf("refusing to adopt existing GCP project after 409: %w", err)
+		}
+
+		return adoptedProject, nil
 	}
 
 	response, err := r.getOperationResponse(ctx, operation)
@@ -418,6 +430,22 @@ func (r *googleGcpReconciler) getOrCreateProject(ctx context.Context, projectID 
 	}
 
 	return createdProject, nil
+}
+
+func validateAdoptedProject(project *cloudresourcemanager.Project, teamSlug string) error {
+	if project.Labels == nil {
+		return fmt.Errorf("project %q has no labels", project.ProjectId)
+	}
+
+	if managedBy := project.Labels[ManagedByLabelName]; managedBy != ManagedByLabelValue {
+		return fmt.Errorf("project %q has unexpected %q label %q", project.ProjectId, ManagedByLabelName, managedBy)
+	}
+
+	if team := project.Labels["team"]; team != teamSlug {
+		return fmt.Errorf("project %q belongs to team %q, expected %q", project.ProjectId, team, teamSlug)
+	}
+
+	return nil
 }
 
 // setProjectPermissions Make sure that the project has the necessary permissions, and don't remove permissions we don't

--- a/internal/reconcilers/google/gcp/reconciler_internal_test.go
+++ b/internal/reconcilers/google/gcp/reconciler_internal_test.go
@@ -1,0 +1,107 @@
+package google_gcp_reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nais/api/pkg/apiclient/protoapi"
+	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/option"
+)
+
+func TestGetOrCreateProject(t *testing.T) {
+	ctx := context.Background()
+	env := &protoapi.TeamEnvironment{EnvironmentName: "dev-gcp"}
+	team := &protoapi.Team{Slug: "team-a"}
+
+	t.Run("adopt existing project on 409 when labels match team", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/v3/projects":
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"error":{"code":409,"message":"already exists"}}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/v3/projects:search":
+				if got := r.URL.Query().Get("query"); got != "id:team-a-dev-0000" {
+					t.Fatalf("unexpected search query: %q", got)
+				}
+				_ = json.NewEncoder(w).Encode(&cloudresourcemanager.SearchProjectsResponse{
+					Projects: []*cloudresourcemanager.Project{{
+						ProjectId: "team-a-dev-0000",
+						Labels: map[string]string{
+							ManagedByLabelName: ManagedByLabelValue,
+							"team":             "team-a",
+						},
+					}},
+				})
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		}))
+		defer server.Close()
+
+		crm, err := cloudresourcemanager.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+		if err != nil {
+			t.Fatalf("new cloudresourcemanager service: %v", err)
+		}
+
+		r := &googleGcpReconciler{
+			gcpServices: &GcpServices{CloudResourceManagerProjectsService: crm.Projects},
+		}
+
+		project, err := r.getOrCreateProject(ctx, "team-a-dev-0000", env, 123, team)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		if got := project.ProjectId; got != "team-a-dev-0000" {
+			t.Fatalf("unexpected project id: %q", got)
+		}
+	})
+
+	t.Run("reject adoption on 409 when labels do not match team", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/v3/projects":
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"error":{"code":409,"message":"already exists"}}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/v3/projects:search":
+				_ = json.NewEncoder(w).Encode(&cloudresourcemanager.SearchProjectsResponse{
+					Projects: []*cloudresourcemanager.Project{{
+						ProjectId: "team-a-dev-0000",
+						Labels: map[string]string{
+							ManagedByLabelName: ManagedByLabelValue,
+							"team":             "team-b",
+						},
+					}},
+				})
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+		}))
+		defer server.Close()
+
+		crm, err := cloudresourcemanager.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+		if err != nil {
+			t.Fatalf("new cloudresourcemanager service: %v", err)
+		}
+
+		r := &googleGcpReconciler{
+			gcpServices: &GcpServices{CloudResourceManagerProjectsService: crm.Projects},
+		}
+
+		_, err = r.getOrCreateProject(ctx, "team-a-dev-0000", env, 123, team)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "refusing to adopt existing GCP project after 409") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/reconcilers/google/gcp/reconciler_test.go
+++ b/internal/reconcilers/google/gcp/reconciler_test.go
@@ -170,6 +170,14 @@ func TestReconcile(t *testing.T) {
 					t.Errorf("expected project id %q, got %q", expectedTeamProjectID, payload.ProjectId)
 				}
 
+				if payload.Labels["team"] != teamSlug {
+					t.Errorf("expected team label %q at creation, got %q", teamSlug, payload.Labels["team"])
+				}
+
+				if payload.Labels[google_gcp_reconciler.ManagedByLabelName] != google_gcp_reconciler.ManagedByLabelValue {
+					t.Errorf("expected managed-by label %q at creation, got %q", google_gcp_reconciler.ManagedByLabelValue, payload.Labels[google_gcp_reconciler.ManagedByLabelName])
+				}
+
 				project := cloudresourcemanager.Project{
 					Name:      payload.DisplayName,
 					ProjectId: payload.ProjectId,


### PR DESCRIPTION
Setter team/managed-by-labels ved prosjektoppretting og verifiserer dem før adopsjon, for å hindre cross-team takeover ved kolliderende prosjekt-ID.